### PR TITLE
Update core

### DIFF
--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -45,15 +45,15 @@ fs.readFile(jsonFilePath, "utf8", (err, jsonString) => {
     fileContent += `import { defineComponent, Type as RecsType, World } from "@latticexyz/recs";\n\n`;
     fileContent += `export function defineContractComponents(world: World) {\n  return {\n`;
 
-    data.components.forEach((component) => {
+    data.models.forEach((model) => {
       let types = []
 
-      const tableName = component.name;
+      const tableName = model.name;
       fileContent += `    ${tableName}: (() => {\n`;
       fileContent += `      const name = "${tableName}";\n`;
       fileContent += `      return defineComponent(\n        world,\n        {\n`;
 
-      component.members.filter(m => !m.key).forEach((member) => {
+      model.members.filter(m => !m.key).forEach((member) => {
         let memberType = cairoToRecsType[member.type] ?? "RecsType.Number";  // Default type set to Number
         fileContent += `          ${member.name}: ${memberType},\n`;
         types.push(member.type);

--- a/packages/core/src/provider/RPCProvider.ts
+++ b/packages/core/src/provider/RPCProvider.ts
@@ -1,4 +1,4 @@
-import { RpcProvider, Account, num, InvokeFunctionResponse, Contract, Result, shortString } from "starknet";
+import { RpcProvider, Account, num, InvokeFunctionResponse, Contract, Result, shortString, InvocationsDetails } from "starknet";
 import { Provider } from "./provider";
 import { Query, WorldEntryPoints } from "../types";
 import { LOCAL_KATANA } from '../constants';
@@ -84,9 +84,16 @@ export class RPCProvider extends Provider {
      * @param {string} contract - The contract to execute.
      * @param {string} call - The function to call.
      * @param {num.BigNumberish[]} call_data - The call data for the function.
+     * @param {InvocationsDetails | undefined} transactionDetails - The transactionDetails allow to override maxFee & version
      * @returns {Promise<InvokeFunctionResponse>} - A promise that resolves to the response of the function execution.
      */
-    public async execute(account: Account, contract: string, call: string, call_data: num.BigNumberish[]): Promise<InvokeFunctionResponse> {
+    public async execute(
+        account: Account,
+        contract: string, 
+        call: string,
+        calldata: num.BigNumberish[],
+        transactionDetails?: InvocationsDetails | undefined
+    ): Promise<InvokeFunctionResponse> {
         try {
             const nonce = await account?.getNonce()
 
@@ -94,12 +101,13 @@ export class RPCProvider extends Provider {
                 {
                     contractAddress: contract,
                     entrypoint: call,
-                    calldata: [this.getWorldAddress()!, ...call_data]
+                    calldata: calldata
                 },
                 undefined,
                 {
+                    maxFee: 0, // TODO: Update this value as needed.
+                    ...transactionDetails,
                     nonce,
-                    maxFee: 0 // TODO: Update this value as needed.
                 }
             );
         } catch (error) {

--- a/packages/core/src/provider/RPCProvider.ts
+++ b/packages/core/src/provider/RPCProvider.ts
@@ -89,7 +89,7 @@ export class RPCProvider extends Provider {
      */
     public async execute(
         account: Account,
-        contract: string, 
+        contract: string,
         call: string,
         calldata: num.BigNumberish[],
         transactionDetails?: InvocationsDetails | undefined


### PR DESCRIPTION
-remove world from execute calldata
contracts should be deploy from world using the deploy_contract fn and world_address will be available from storage
https://github.com/dojoengine/dojo/blob/b9bb4380adbbd7a14728725f5aa39e950e95abbb/crates/dojo-core/src/world.cairo#L289

-allow to specify transactionDetails to override maxFee/version

-update generateComponents to use models